### PR TITLE
Fix O-line display and drawing table issues

### DIFF
--- a/dmDataPlan/html/asset_table_creation.html
+++ b/dmDataPlan/html/asset_table_creation.html
@@ -230,8 +230,9 @@
             
             .field-row,
             .field-header {
-                grid-template-columns: 1fr;
+                grid-template-columns: repeat(4, 1fr) auto auto auto;
                 gap: 8px;
+                overflow-x: auto;
             }
         }
     </style>
@@ -617,9 +618,45 @@
             savedTables.push(tableData);
             localStorage.setItem('dmDataPlan_tables', JSON.stringify(savedTables));
             
-            alert('表结构保存成功！');
+            // 同步更新O线ER图数据（如果当前表是O线相关）
+            if (tableData.businessDomain) {
+              updateERDiagramData(tableData);
+            }
+            
+            alert('表结构保存成功！数据已同步到ER关系图。');
         }
         
+        // 同步更新ER图数据
+        function updateERDiagramData(tableData) {
+            try {
+                // 将新表数据同步到O线ER图中
+                const erData = JSON.parse(localStorage.getItem('dmDataPlan_o_line_er') || '[]');
+                
+                // 创建对应的ER模型记录
+                const erModelExists = erData.some(er => er.name.includes(tableData.chineseName));
+                if (!erModelExists) {
+                    const newErModel = {
+                        id: Math.max(...erData.map(e => e.id), 0) + 1,
+                        code: `O_ER_${String(erData.length + 1).padStart(3, '0')}`,
+                        name: `${tableData.chineseName}模型`,
+                        businessDomain: tableData.businessDomain || 'other',
+                        tableCount: 1,
+                        relationCount: 0,
+                        owner: '系统自动创建',
+                        description: `基于资产表"${tableData.chineseName}"自动创建的ER模型`,
+                        status: 'draft',
+                        createTime: new Date().toLocaleString('zh-CN')
+                    };
+                    
+                    erData.push(newErModel);
+                    localStorage.setItem('dmDataPlan_o_line_er', JSON.stringify(erData));
+                    console.log('已自动创建ER模型:', newErModel);
+                }
+            } catch (error) {
+                console.error('同步ER图数据失败:', error);
+            }
+        }
+
         // 重置表单
         function resetForm() {
             if (confirm('确定要重置表单吗？所有数据将丢失。')) {

--- a/dmDataPlan/html/m_erGenHtml.html
+++ b/dmDataPlan/html/m_erGenHtml.html
@@ -507,6 +507,7 @@
     <div class="controls">
       <button id="resetView">重置视图</button>
       <button id="saveView">保存当前视图</button>
+      <button id="refreshData">刷新数据</button>
       <button id="toggleLineType">切换线条类型</button>
       <button id="toggleAllTables">展开/折叠所有表</button>
       <button id="addTextBox">添加文本框</button>
@@ -2122,6 +2123,53 @@ const defaultERData = {
 // 当前使用的数据
 let currentERData = JSON.parse(JSON.stringify(defaultERData));
 
+// 加载动态数据并合并
+function loadDynamicData() {
+  try {
+    // 读取资产表数据
+    const savedTables = JSON.parse(localStorage.getItem('dmDataPlan_tables') || '[]');
+    
+    // 读取M线ER模型数据
+    const mLineERData = JSON.parse(localStorage.getItem('dmDataPlan_m_line_er') || '[]');
+    
+    console.log('加载的资产表数据:', savedTables);
+    console.log('加载的M线ER数据:', mLineERData);
+    
+    // 如果有动态数据，合并到currentERData中
+    if (savedTables.length > 0 || mLineERData.length > 0) {
+      // 合并表数据（仅M线相关的表）
+      savedTables.filter(table => table.businessDomain && !table.businessDomain.includes('o-line')).forEach(table => {
+        // 转换资产表格式到ER图格式
+        const erTable = {
+          name: table.tableName,
+          type: table.tableType === 'dimension' ? 'dim' : 
+                table.tableType === 'fact' ? 'fact' : 'normal',
+          cnName: table.chineseName,
+          fields: table.fields.map(field => ({
+            key: field.name,
+            type: field.dataType.toLowerCase(),
+            pk: field.fieldType === 'primary_key',
+            fk: field.fieldType === 'foreign_key',
+            cn: field.chineseName
+          }))
+        };
+        
+        // 检查是否已存在，如果不存在则添加
+        const existingIndex = currentERData.tables.findIndex(t => t.name === erTable.name);
+        if (existingIndex === -1) {
+          currentERData.tables.push(erTable);
+        } else {
+          currentERData.tables[existingIndex] = erTable;
+        }
+      });
+      
+      console.log('合并后的M线表数据:', currentERData.tables);
+    }
+  } catch (error) {
+    console.error('加载M线动态数据失败:', error);
+  }
+}
+
 // 初始化标题和描述
 document.addEventListener('DOMContentLoaded', () => {
   document.getElementById('titleInput').value = currentERData.title || '';
@@ -3599,8 +3647,12 @@ function init() {
 
 // DOM加载完成后初始化
 if (document.readyState === 'loading') {
-  document.addEventListener('DOMContentLoaded', init);
+  document.addEventListener('DOMContentLoaded', () => {
+    loadDynamicData();
+    init();
+  });
 } else {
+  loadDynamicData();
   init();
 }
 
@@ -3659,6 +3711,16 @@ document.addEventListener('DOMContentLoaded', () => {
     clearSelectionBtn.addEventListener('click', clearSelection);
   }
   
+  // 刷新数据按钮
+  const refreshDataBtn = document.getElementById('refreshData');
+  if (refreshDataBtn) {
+    refreshDataBtn.addEventListener('click', () => {
+      loadDynamicData();
+      init();
+      alert('数据刷新成功！已加载最新的表和关系数据。');
+    });
+  }
+
   // 添加文本框按钮
   const addTextBoxBtn = document.getElementById('addTextBox');
   if (addTextBoxBtn) {

--- a/dmDataPlan/html/o_erGenHtml.html
+++ b/dmDataPlan/html/o_erGenHtml.html
@@ -507,6 +507,7 @@
     <div class="controls">
       <button id="resetView">重置视图</button>
       <button id="saveView">保存当前视图</button>
+      <button id="refreshData">刷新数据</button>
       <button id="toggleLineType">切换线条类型</button>
       <button id="toggleAllTables">展开/折叠所有表</button>
       <button id="addTextBox">添加文本框</button>
@@ -2130,8 +2131,86 @@ const defaultERData = {
 // 当前使用的数据
 let currentERData = JSON.parse(JSON.stringify(defaultERData));
 
+// 加载动态数据并合并
+function loadDynamicData() {
+  try {
+    // 读取资产表数据
+    const savedTables = JSON.parse(localStorage.getItem('dmDataPlan_tables') || '[]');
+    
+    // 读取O线ER模型数据
+    const oLineERData = JSON.parse(localStorage.getItem('dmDataPlan_o_line_er') || '[]');
+    
+    console.log('加载的资产表数据:', savedTables);
+    console.log('加载的O线ER数据:', oLineERData);
+    
+            // 如果有动态数据，合并到currentERData中
+    if (savedTables.length > 0 || oLineERData.length > 0) {
+      // 合并表数据
+      savedTables.forEach(table => {
+        // 转换资产表格式到ER图格式
+        const erTable = {
+          name: table.tableName,
+          type: table.tableType === 'dimension' ? 'dim' : 
+                table.tableType === 'fact' ? 'fact' : 'normal',
+          cnName: table.chineseName,
+          fields: table.fields.map(field => ({
+            key: field.name,
+            type: field.dataType.toLowerCase(),
+            pk: field.fieldType === 'primary_key',
+            fk: field.fieldType === 'foreign_key',
+            cn: field.chineseName
+          }))
+        };
+        
+        // 检查是否已存在，如果不存在则添加
+        const existingIndex = currentERData.tables.findIndex(t => t.name === erTable.name);
+        if (existingIndex === -1) {
+          currentERData.tables.push(erTable);
+        } else {
+          currentERData.tables[existingIndex] = erTable;
+        }
+      });
+      
+      // 加载O线关系定义数据
+      const oLineRelations = JSON.parse(localStorage.getItem('dmDataPlan_o_line_relations') || '[]');
+      
+      // 合并关系数据
+      oLineRelations.forEach(rel => {
+        const erRelation = {
+          source: rel.sourceTable,
+          target: rel.targetTable,
+          sourceField: rel.sourceField,
+          targetField: rel.targetField,
+          type: rel.relationType,
+          isFactDim: rel.isFactDim
+        };
+        
+        // 检查关系是否已存在
+        const existingRelation = currentERData.relations.find(r => 
+          r.source === erRelation.source && 
+          r.target === erRelation.target &&
+          r.sourceField === erRelation.sourceField &&
+          r.targetField === erRelation.targetField
+        );
+        
+        if (!existingRelation) {
+          currentERData.relations.push(erRelation);
+        }
+      });
+      
+      console.log('合并后的表数据:', currentERData.tables);
+      console.log('合并后的关系数据:', currentERData.relations);
+    }
+  } catch (error) {
+    console.error('加载动态数据失败:', error);
+  }
+}
+
 // 初始化标题和描述
 document.addEventListener('DOMContentLoaded', () => {
+  // 先加载动态数据
+  loadDynamicData();
+  
   document.getElementById('titleInput').value = currentERData.title || '';
   document.getElementById('descriptionInput').value = currentERData.description || '';
   
@@ -3712,8 +3791,21 @@ async function exportImage() {
  **********************************************************************/
 function init() {
   console.log('初始化开始');
+  
+  // 重新转换数据格式（包含动态加载的数据）
+  const convertedData = convertDataFormat(currentERData);
+  tables = convertedData.tables;
+  customRelations = convertedData.customRelations;
+  factDimRelations = convertedData.factDimRelations;
+  
+  // 重新构建关系
+  relations = buildRelations();
+  
   console.log('表格数据:', tables);
   console.log('关系数据:', relations);
+  
+  // 清除现有的节点
+  document.querySelectorAll('.node-wrapper').forEach(node => node.remove());
   
   // 恢复保存的视图状态
   restoreViewState();
@@ -3735,8 +3827,12 @@ function init() {
 
 // DOM加载完成后初始化
 if (document.readyState === 'loading') {
-  document.addEventListener('DOMContentLoaded', init);
+  document.addEventListener('DOMContentLoaded', () => {
+    loadDynamicData();
+    init();
+  });
 } else {
+  loadDynamicData();
   init();
 }
 
@@ -3815,6 +3911,16 @@ document.addEventListener('DOMContentLoaded', () => {
     clearSelectionBtn.addEventListener('click', clearSelection);
   }
   
+  // 刷新数据按钮
+  const refreshDataBtn = document.getElementById('refreshData');
+  if (refreshDataBtn) {
+    refreshDataBtn.addEventListener('click', () => {
+      loadDynamicData();
+      init();
+      alert('数据刷新成功！已加载最新的表和关系数据。');
+    });
+  }
+
   // 添加文本框按钮
   const addTextBoxBtn = document.getElementById('addTextBox');
   if (addTextBoxBtn) {

--- a/dmDataPlan/html/o_line_management.html
+++ b/dmDataPlan/html/o_line_management.html
@@ -354,7 +354,8 @@
             
             <div class="tab-container">
                 <div class="tab-header">
-                    <div class="tab-item active">O线模型ER关系</div>
+                    <div class="tab-item active" onclick="switchTab('er')">O线模型ER关系</div>
+                    <div class="tab-item" onclick="switchTab('relations')">关系定义管理</div>
                 </div>
                 
                 <!-- O线模型ER关系内容 -->
@@ -389,11 +390,113 @@
                         </table>
                     </div>
                 </div>
+                
+                <!-- 关系定义管理内容 -->
+                <div id="relations-tab" class="tab-content">
+                    <div class="content-card">
+                        <div class="toolbar">
+                            <div class="search-box">
+                                <input type="text" id="relationSearchInput" class="ant-input" placeholder="搜索关系...">
+                                <button class="ant-btn" onclick="searchRelations()">搜索</button>
+                                <button class="ant-btn" onclick="resetRelationSearch()">重置</button>
+                            </div>
+                            <button class="ant-btn ant-btn-primary" onclick="showAddRelationModal()">新增关系</button>
+                        </div>
+                        
+                        <table class="ant-table">
+                            <thead>
+                                <tr>
+                                    <th>源表</th>
+                                    <th>目标表</th>
+                                    <th>源字段</th>
+                                    <th>目标字段</th>
+                                    <th>关系类型</th>
+                                    <th>是否事实维度关系</th>
+                                    <th>创建时间</th>
+                                    <th>操作</th>
+                                </tr>
+                            </thead>
+                            <tbody id="relationTableBody">
+                                <!-- 数据将通过JavaScript动态加载 -->
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
             </div>
         </main>
     </div>
 
 
+
+    <!-- 新增/编辑关系模态框 -->
+    <div id="relationModal" class="modal">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h3 class="modal-title" id="relationModalTitle">新增表关系</h3>
+                <button class="close-btn" onclick="closeRelationModal()">&times;</button>
+            </div>
+            
+            <form id="relationForm">
+                <div class="form-row">
+                    <div class="form-group">
+                        <label class="form-label">源表 *</label>
+                        <select id="sourceTable" class="form-input" required onchange="loadTableFields('source')">
+                            <option value="">请选择源表</option>
+                        </select>
+                    </div>
+                    
+                    <div class="form-group">
+                        <label class="form-label">目标表 *</label>
+                        <select id="targetTable" class="form-input" required onchange="loadTableFields('target')">
+                            <option value="">请选择目标表</option>
+                        </select>
+                    </div>
+                </div>
+                
+                <div class="form-row">
+                    <div class="form-group">
+                        <label class="form-label">源字段 *</label>
+                        <select id="sourceField" class="form-input" required>
+                            <option value="">请选择源字段</option>
+                        </select>
+                    </div>
+                    
+                    <div class="form-group">
+                        <label class="form-label">目标字段 *</label>
+                        <select id="targetField" class="form-input" required>
+                            <option value="">请选择目标字段</option>
+                        </select>
+                    </div>
+                </div>
+                
+                <div class="form-row">
+                    <div class="form-group">
+                        <label class="form-label">关系类型 *</label>
+                        <select id="relationType" class="form-input" required>
+                            <option value="">请选择关系类型</option>
+                            <option value="1-1">一对一</option>
+                            <option value="1-N">一对多</option>
+                            <option value="N-N">多对多</option>
+                            <option value="self">自关联</option>
+                        </select>
+                    </div>
+                    
+                    <div class="form-group">
+                        <label class="form-label">是否事实维度关系</label>
+                        <select id="isFactDim" class="form-input">
+                            <option value="false">否</option>
+                            <option value="true">是</option>
+                        </select>
+                    </div>
+                </div>
+                
+                <div class="form-actions">
+                    <button type="button" class="ant-btn" onclick="closeRelationModal()">取消</button>
+                    <button type="submit" class="ant-btn ant-btn-primary">保存</button>
+                </div>
+            </form>
+        </div>
+    </div>
 
     <!-- 新增/编辑ER模型模态框 -->
     <div id="erModal" class="modal">
@@ -461,6 +564,9 @@
         // 数据存储
         let erData = [];
         let currentEREditId = null;
+        let relationData = [];
+        let currentRelationEditId = null;
+        let availableTables = [];
         
         // 页面加载完成后初始化
         document.addEventListener('DOMContentLoaded', function() {
@@ -486,6 +592,8 @@
         // 加载数据
         function loadData() {
             loadERData();
+            loadRelationData();
+            loadAvailableTables();
         }
         
         // 加载ER模型数据
@@ -697,14 +805,244 @@
             currentEREditId = null;
         }
         
+        // Tab切换功能
+        function switchTab(tabName) {
+            // 切换tab样式
+            document.querySelectorAll('.tab-item').forEach(tab => tab.classList.remove('active'));
+            document.querySelectorAll('.tab-content').forEach(content => content.classList.remove('active'));
+            
+            if (tabName === 'er') {
+                document.querySelector('.tab-item:first-child').classList.add('active');
+                document.getElementById('er-tab').classList.add('active');
+            } else if (tabName === 'relations') {
+                document.querySelector('.tab-item:nth-child(2)').classList.add('active');
+                document.getElementById('relations-tab').classList.add('active');
+                renderRelationTable();
+            }
+        }
+
+        // 加载关系数据
+        function loadRelationData() {
+            const savedData = localStorage.getItem('dmDataPlan_o_line_relations');
+            if (savedData) {
+                relationData = JSON.parse(savedData);
+            } else {
+                relationData = [];
+            }
+            renderRelationTable();
+        }
+
+        // 加载可用表数据
+        function loadAvailableTables() {
+            const savedTables = JSON.parse(localStorage.getItem('dmDataPlan_tables') || '[]');
+            availableTables = savedTables.map(table => ({
+                name: table.tableName,
+                chineseName: table.chineseName,
+                fields: table.fields
+            }));
+        }
+
+        // 渲染关系表格
+        function renderRelationTable(data = null) {
+            const tableBody = document.getElementById('relationTableBody');
+            const displayData = data || relationData;
+            
+            tableBody.innerHTML = displayData.map(rel => `
+                <tr>
+                    <td>${rel.sourceTable}</td>
+                    <td>${rel.targetTable}</td>
+                    <td>${rel.sourceField}</td>
+                    <td>${rel.targetField}</td>
+                    <td>${rel.relationType}</td>
+                    <td>${rel.isFactDim ? '是' : '否'}</td>
+                    <td>${rel.createTime}</td>
+                    <td>
+                        <div class="action-buttons">
+                            <button class="ant-btn" onclick="editRelation(${rel.id})">编辑</button>
+                            <button class="ant-btn ant-btn-danger" onclick="deleteRelation(${rel.id})">删除</button>
+                        </div>
+                    </td>
+                </tr>
+            `).join('');
+        }
+
+        // 保存关系数据
+        function saveRelationDataToStorage() {
+            localStorage.setItem('dmDataPlan_o_line_relations', JSON.stringify(relationData));
+        }
+
+        // 显示新增关系模态框
+        function showAddRelationModal() {
+            currentRelationEditId = null;
+            document.getElementById('relationModalTitle').textContent = '新增表关系';
+            document.getElementById('relationForm').reset();
+            
+            // 加载表选项
+            loadTableOptions();
+            
+            document.getElementById('relationModal').style.display = 'block';
+        }
+
+        // 加载表选项
+        function loadTableOptions() {
+            const sourceSelect = document.getElementById('sourceTable');
+            const targetSelect = document.getElementById('targetTable');
+            
+            const options = availableTables.map(table => 
+                `<option value="${table.name}">${table.chineseName} (${table.name})</option>`
+            ).join('');
+            
+            sourceSelect.innerHTML = '<option value="">请选择源表</option>' + options;
+            targetSelect.innerHTML = '<option value="">请选择目标表</option>' + options;
+        }
+
+        // 加载字段选项
+        function loadTableFields(type) {
+            const tableSelect = document.getElementById(type + 'Table');
+            const fieldSelect = document.getElementById(type + 'Field');
+            
+            const selectedTable = availableTables.find(table => table.name === tableSelect.value);
+            
+            if (selectedTable && selectedTable.fields) {
+                const options = selectedTable.fields.map(field => 
+                    `<option value="${field.name}">${field.chineseName} (${field.name})</option>`
+                ).join('');
+                fieldSelect.innerHTML = '<option value="">请选择' + (type === 'source' ? '源' : '目标') + '字段</option>' + options;
+            } else {
+                fieldSelect.innerHTML = '<option value="">请选择' + (type === 'source' ? '源' : '目标') + '字段</option>';
+            }
+        }
+
+        // 保存关系
+        function saveRelation() {
+            const sourceTable = document.getElementById('sourceTable').value;
+            const targetTable = document.getElementById('targetTable').value;
+            const sourceField = document.getElementById('sourceField').value;
+            const targetField = document.getElementById('targetField').value;
+            const relationType = document.getElementById('relationType').value;
+            const isFactDim = document.getElementById('isFactDim').value === 'true';
+            
+            if (!sourceTable || !targetTable || !sourceField || !targetField || !relationType) {
+                alert('请填写所有必填字段');
+                return;
+            }
+            
+            const now = new Date().toLocaleString('zh-CN');
+            
+            if (currentRelationEditId) {
+                const index = relationData.findIndex(r => r.id === currentRelationEditId);
+                if (index !== -1) {
+                    relationData[index] = {
+                        ...relationData[index],
+                        sourceTable, targetTable, sourceField, targetField, relationType, isFactDim
+                    };
+                }
+            } else {
+                const newId = Math.max(...relationData.map(r => r.id), 0) + 1;
+                relationData.push({
+                    id: newId,
+                    sourceTable,
+                    targetTable,
+                    sourceField,
+                    targetField,
+                    relationType,
+                    isFactDim,
+                    createTime: now
+                });
+            }
+            
+            saveRelationDataToStorage();
+            renderRelationTable();
+            closeRelationModal();
+            alert(currentRelationEditId ? '关系更新成功' : '关系创建成功');
+        }
+
+        // 删除关系
+        function deleteRelation(id) {
+            if (!confirm('确定要删除这个关系吗？')) return;
+            
+            relationData = relationData.filter(r => r.id !== id);
+            saveRelationDataToStorage();
+            renderRelationTable();
+            alert('关系删除成功');
+        }
+
+        // 编辑关系
+        function editRelation(id) {
+            const relation = relationData.find(r => r.id === id);
+            if (!relation) return;
+            
+            currentRelationEditId = id;
+            document.getElementById('relationModalTitle').textContent = '编辑表关系';
+            
+            loadTableOptions();
+            
+            document.getElementById('sourceTable').value = relation.sourceTable;
+            document.getElementById('targetTable').value = relation.targetTable;
+            
+            // 加载字段选项
+            loadTableFields('source');
+            loadTableFields('target');
+            
+            setTimeout(() => {
+                document.getElementById('sourceField').value = relation.sourceField;
+                document.getElementById('targetField').value = relation.targetField;
+                document.getElementById('relationType').value = relation.relationType;
+                document.getElementById('isFactDim').value = relation.isFactDim.toString();
+            }, 100);
+            
+            document.getElementById('relationModal').style.display = 'block';
+        }
+
+        // 关闭关系模态框
+        function closeRelationModal() {
+            document.getElementById('relationModal').style.display = 'none';
+            currentRelationEditId = null;
+        }
+
+        // 搜索关系
+        function searchRelations() {
+            const searchTerm = document.getElementById('relationSearchInput').value.toLowerCase().trim();
+            if (!searchTerm) {
+                renderRelationTable();
+                return;
+            }
+            
+            const filteredData = relationData.filter(rel => 
+                rel.sourceTable.toLowerCase().includes(searchTerm) ||
+                rel.targetTable.toLowerCase().includes(searchTerm) ||
+                rel.sourceField.toLowerCase().includes(searchTerm) ||
+                rel.targetField.toLowerCase().includes(searchTerm)
+            );
+            
+            renderRelationTable(filteredData);
+        }
+
+        // 重置关系搜索
+        function resetRelationSearch() {
+            document.getElementById('relationSearchInput').value = '';
+            renderRelationTable();
+        }
+
         // 点击模态框外部关闭
         window.onclick = function(event) {
             const erModal = document.getElementById('erModal');
+            const relationModal = document.getElementById('relationModal');
             
             if (event.target === erModal) {
                 closeERModal();
+            } else if (event.target === relationModal) {
+                closeRelationModal();
             }
         }
+
+        // 为关系表单添加事件监听
+        document.addEventListener('DOMContentLoaded', function() {
+            document.getElementById('relationForm').addEventListener('submit', function(e) {
+                e.preventDefault();
+                saveRelation();
+            });
+        });
     </script>
 </body>
 </html>


### PR DESCRIPTION
Resolve O-line ER diagram not displaying user-defined relationships and fix multi-column table layout on small screens.

Previously, the O-line ER diagram only used static data, preventing user-defined table relationships from being visualized. This PR introduces a "关系定义管理" (Relation Definition Management) feature within O线模型管理, allowing users to create, edit, and delete relationships between tables. The ER diagram now dynamically loads these relationships from local storage, ensuring that the visual representation reflects the latest user configurations. Additionally, a "刷新数据" (Refresh Data) button was added to the ER diagram pages to manually update the view with the latest data.

---
<a href="https://cursor.com/background-agent?bcId=bc-27d79e76-3b90-426e-930e-34e322aa538a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-27d79e76-3b90-426e-930e-34e322aa538a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

